### PR TITLE
Add UPnP 1.1 and InternetGatewayDevice:2 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>upnplib</groupId>
+  <groupId>net.sbbi.upnp</groupId>
   <artifactId>upnplib</artifactId>
-  <version>1.0.9-nodebug</version>
+  <version>1.0.10-nodebug</version>
   <name>upnplib</name>
   <description>RPTools UPNP 1.0 library</description>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.0</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <excludes>
             <exclude>net/sbbi/upnp/jmx/**</exclude>
           </excludes>

--- a/src/net/sbbi/upnp/devices/UPNPRootDevice.java
+++ b/src/net/sbbi/upnp/devices/UPNPRootDevice.java
@@ -358,6 +358,9 @@ public class UPNPRootDevice extends UPNPDevice {
 	 */
 	private void fillUPNPServicesList(UPNPDevice device, JXPathContext deviceCtx) throws MalformedURLException {
 		Pointer serviceListPtr = deviceCtx.getPointer("upnp:serviceList");
+		if (serviceListPtr == null) {
+			return;
+		}
 		JXPathContext serviceListCtx = deviceCtx.getRelativeContext(serviceListPtr);
 		Double arraySize = (Double) serviceListCtx.getValue("count( upnp:service )");
 		if (log.isDebugEnabled())

--- a/src/net/sbbi/upnp/devices/UPNPRootDevice.java
+++ b/src/net/sbbi/upnp/devices/UPNPRootDevice.java
@@ -141,7 +141,7 @@ public class UPNPRootDevice extends UPNPDevice {
 		specVersionMajor = Integer.parseInt((String) rootCtx.getValue("upnp:specVersion/upnp:major"));
 		specVersionMinor = Integer.parseInt((String) rootCtx.getValue("upnp:specVersion/upnp:minor"));
 
-		if (!(specVersionMajor == 1 && specVersionMinor == 0)) {
+		if (!(specVersionMajor == 1)) {
 			throw new IllegalStateException("Unsupported device version (" + specVersionMajor + "." + specVersionMinor + ")");
 		}
 		boolean buildURLBase = true;

--- a/src/net/sbbi/upnp/version.properties
+++ b/src/net/sbbi/upnp/version.properties
@@ -1,8 +1,8 @@
 # please make sur to update those values
 # when creating a new release
 # especially to create cvs changelogs
-release.version=1.0.9
-release.version.cvs.tag=V1_0_9
-release.version.publish.date=22 Apr 2013
-last.release.version.cvs.tag=V1_0_4
-last.release.version.publish.date=20 Nov 2006
+release.version=1.0.10
+release.version.cvs.tag=V1_0_10
+release.version.publish.date=22 Dec 2024
+last.release.version.cvs.tag=V1_0_9
+last.release.version.publish.date=22 Apr 2013


### PR DESCRIPTION
These are the changes I needed to make to support my Unifi.
I can't speak for other people's routers, but the UPnP 1.0-only support was enough that I haven't had UPnP support for most of a decade, and the IGD:2 support is also needed for Unifi devices.
Hopefully this will help other people's devices too.

This is targeted at the develop branch since that appears to be what MapTool is actually using instead of main, and will need a jar to be added to the maven repository to include it in MapTool builds.

Closes https://github.com/RPTools/upnplib/issues/8
Closes https://github.com/RPTools/upnplib/issues/6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/upnplib/9)
<!-- Reviewable:end -->
